### PR TITLE
Jk/add onscroll

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 npm-debug.log
 android/app/build
 .vscode
+.watchmanconfig

--- a/index.js
+++ b/index.js
@@ -1,2 +1,3 @@
 export { default } from './src/WeekView/WeekView';
-export { addLocale } from './src/utils';
+export { addLocale, CONTAINER_HEIGHT } from './src/utils';
+export { default as Header } from './src/Header/Header';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dali-lab/react-native-week-view",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Week View Calendar for React Native",
   "main": "index.js",
   "author": "Hoang Nguyen (https://github.com/hoangnm)",

--- a/src/WeekView/WeekView.js
+++ b/src/WeekView/WeekView.js
@@ -305,7 +305,11 @@ export default class WeekView extends Component {
           />
         </View>
         {/* Fixed below reference */}
-        <ScrollView ref={this.verticalAgenda}>
+        <ScrollView
+          ref={this.verticalAgenda}
+          onScroll={this.props.handleScroll}
+          scrollEventThrottle={64}
+        >
           <View style={styles.scrollViewContent}>
             <Times times={times} textStyle={hourTextStyle} />
             <VirtualizedList
@@ -376,6 +380,7 @@ WeekView.propTypes = {
   EventComponent: PropTypes.elementType,
   rightToLeft: PropTypes.bool,
   prependMostRecent: PropTypes.bool,
+  handleScroll: PropTypes.func,
 };
 
 WeekView.defaultProps = {


### PR DESCRIPTION
# Description

Added `onScroll` listener for calendar views. Can be hooked into the `handleScroll` prop, which takes in a function.

Cleaned up exports to be more accessible
## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update

